### PR TITLE
Harden install script publishing

### DIFF
--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -8,20 +8,20 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  sign-install-script:
+  publish-install-scripts:
     runs-on: windows-2022
+    if: github.ref == 'refs/heads/main'
     environment: production
 
     permissions:
-      contents: read
+      contents: write
       id-token: write
-
-    outputs:
-      signing_enabled: ${{ steps.signing.outputs.enabled }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
@@ -94,32 +94,6 @@ jobs:
           exclude-azure-developer-cli-credential: true
           exclude-interactive-browser-credential: true
 
-      - name: Upload staged install scripts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
-        with:
-          name: staged-install-scripts
-          path: ./artifacts/install-script/*
-          retention-days: 7
-
-  publish-install-scripts:
-    runs-on: ubuntu-latest
-    needs: sign-install-script
-
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          fetch-depth: 0
-
-      - name: Download staged install scripts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: staged-install-scripts
-          path: ./artifacts/install-script
-
       - name: Generate install script manifest
         id: manifest
         shell: pwsh
@@ -154,4 +128,4 @@ jobs:
           echo "- **Branch:** \`install-scripts\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Version:** \`${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Source commit:** \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Signing enabled:** \`${{ needs.sign-install-script.outputs.signing_enabled }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Signing enabled:** \`${{ steps.signing.outputs.enabled }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ If you turn this into a real repository, start here:
 2. Update `Directory.Build.props` metadata, especially `RepositoryUrl`.
 3. Replace the sample commands in `Program.cs` and `Commands\`.
 4. Review installer defaults in `scripts\install\install-templatecli.ps1` and `install-templatecli.sh`.
-5. Update README examples and any remaining placeholder strings like `example/templatecli`.
-6. If you change persisted models, register them in `Models\JsonContext.cs`.
+5. Configure the `production` environment and installer branch/tag rulesets before first install-script publication.
+6. Update README examples and any remaining placeholder strings like `example/templatecli`.
+7. If you change persisted models, register them in `Models\JsonContext.cs`.
 
 ## Release, signing, and provenance
 

--- a/docs/release-and-provenance.md
+++ b/docs/release-and-provenance.md
@@ -31,7 +31,64 @@ Latest bootstrap URLs come from the branch, for example:
 
 This design supports both mutable and immutable consumption. The branch-backed URLs provide a convenient "latest" bootstrap entry point, while each publication also creates a tag-bound immutable snapshot release that consumers can pin to when they want a fixed install-script version.
 
-The `install-scripts` branch is treated as workflow-managed mutable state. Repositories created from this template typically will not have that branch yet unless the creator explicitly chose to include all branches, so the publication flow is expected to create `install-scripts` on first publish when it is missing. If repository permissions or branch protection prevent the workflow from creating or force-updating that branch, the workflow should fail with a clear, actionable error.
+The `install-scripts` branch is treated as workflow-managed mutable state. Repositories created from this template typically will not have that branch yet unless the creator explicitly chose to include all branches, so the publication flow is expected to create `install-scripts` on first publish when it is missing. Subsequent publications add regular commits so the branch history is preserved. If repository permissions or branch protection prevent the workflow from creating or updating that branch, the workflow should fail with a clear, actionable error.
+
+`install-scripts.yml` uses the `production` environment for the single approval gate before signing keys are accessed or the public `install-scripts` branch and snapshot tag are updated. `attest-install-scripts.yml` intentionally remains ungated and only publishes attestations and the immutable release for the already-approved snapshot tag.
+
+## Required repository setup
+
+Before publishing official releases or install scripts, configure the repository so the workflows can use the `production` environment and the workflow-managed branches and tags cannot be accidentally destroyed.
+
+### `production` environment
+
+Create a repository environment named `production`. This environment is the single approval gate for operations that either use signing credentials or publish public release/install assets.
+
+Recommended environment settings:
+
+- Add required reviewers for release/install publication approval.
+- If more than one reviewer is available, enable **Prevent self-review**.
+- Use **Selected branches and tags** for deployment branches/tags.
+- Allow the `main` branch so `install-scripts.yml` can publish install scripts.
+- Allow `v*` tags so `release.yml` can sign and publish official release assets.
+- Leave `install-scripts-v*` tags out unless `attest-install-scripts.yml` is later changed to use the `production` environment.
+- Disable administrator bypass if the approval gate should apply even to repository administrators; otherwise leave it enabled as an emergency escape hatch.
+
+### `install-scripts` branch ruleset
+
+Create a branch ruleset targeting exactly:
+
+```text
+install-scripts
+```
+
+The minimal ruleset that still allows the workflow to publish with the default `GITHUB_TOKEN` is:
+
+- **Restrict deletions**: enabled
+- **Block force pushes**: enabled
+- **Restrict creations**: disabled
+- **Restrict updates**: disabled
+- Bypass list: empty
+
+This protects the mutable installer branch from deletion and history rewrites while still allowing `install-scripts.yml` to create the branch on first publish and push regular history-preserving updates on subsequent publishes.
+
+To also block direct human pushes, use a dedicated machine identity instead of the default `GITHUB_TOKEN`: create a GitHub App or write deploy key, add that actor to the ruleset bypass list, store its credentials in the `production` environment, and have `install-scripts.yml` push with that token/key. Then enable **Restrict creations** and **Restrict updates** for the `install-scripts` ruleset.
+
+### Install-script snapshot tag ruleset
+
+Create a tag ruleset targeting:
+
+```text
+install-scripts-v*
+```
+
+Recommended rules:
+
+- **Restrict deletions**: enabled
+- **Restrict updates**: enabled
+- **Restrict creations**: disabled
+- Bypass list: empty
+
+`install-scripts.yml` creates a new snapshot tag for each publication and fails if the tag already exists, so updates and deletions should not be needed after creation.
 
 ## Optional repository configuration
 

--- a/scripts/publish-branch-content.sh
+++ b/scripts/publish-branch-content.sh
@@ -43,11 +43,10 @@ cp -R "$SOURCE_DIR"/. "$WORKTREE_DIR"/
 git -C "$WORKTREE_DIR" add -A
 
 if git -C "$WORKTREE_DIR" diff --cached --quiet; then
-  git -C "$WORKTREE_DIR" push origin "HEAD:${BRANCH}" --force >/dev/null
   git -C "$WORKTREE_DIR" rev-parse HEAD
   exit 0
 fi
 
 git -C "$WORKTREE_DIR" -c user.name="${GIT_AUTHOR_NAME:-github-actions[bot]}" -c user.email="${GIT_AUTHOR_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}" commit -m "$COMMIT_MESSAGE" >/dev/null
-git -C "$WORKTREE_DIR" push origin "HEAD:${BRANCH}" --force >/dev/null
+git -C "$WORKTREE_DIR" push origin "HEAD:${BRANCH}" >/dev/null
 git -C "$WORKTREE_DIR" rev-parse HEAD


### PR DESCRIPTION
## Summary
- Preserve `install-scripts` branch history by replacing force-push publication with normal pushes
- Consolidate install-script signing and branch/tag publication into one `production`-gated workflow job on `main`
- Document required `production` environment, installer branch ruleset, and snapshot tag ruleset setup

## Validation
- `git diff --check`
- `bash -n scripts/publish-branch-content.sh`
- `bash scripts/verify-shell-syntax.sh`