### PR TITLE
Configure install script tag identity

### DIFF
--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -117,6 +117,8 @@ jobs:
             exit 1
           fi
 
+          git config user.name "${GIT_AUTHOR_NAME:-github-actions[bot]}"
+          git config user.email "${GIT_AUTHOR_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
           git tag -a "$VERSION" "$BRANCH_COMMIT" -m "Published install scripts snapshot ${VERSION}"
           git push origin "$VERSION"
 


### PR DESCRIPTION
## Summary
- Configure the GitHub Actions bot Git identity before creating the annotated `install-scripts-v*` snapshot tag
- Fixes the first install-script publication failure after the `install-scripts` branch is created successfully

## Validation
- `git diff --check`
- `bash scripts/verify-shell-syntax.sh`