### PR TITLE
Allow installer workflow attestation dispatch

### DIFF
--- a/.github/workflows/attest-install-scripts.yml
+++ b/.github/workflows/attest-install-scripts.yml
@@ -3,6 +3,10 @@ name: Attest Install Scripts
 on:
   workflow_dispatch:
 
+concurrency:
+  group: attest-install-scripts-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   attest-and-release:
     runs-on: ubuntu-latest
@@ -31,7 +35,9 @@ jobs:
       - name: Attest published install scripts
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
-          subject-path: ./install.sh,./install.ps1
+          subject-path: |
+            ./install.sh
+            ./install.ps1
 
       - name: Publish immutable install script snapshot
         env:

--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -33,8 +33,10 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Path ./artifacts/install-script -Force | Out-Null
+          New-Item -ItemType Directory -Path ./artifacts/install-script/.github/workflows -Force | Out-Null
           Copy-Item ./scripts/install/install-templatecli.ps1 ./artifacts/install-script/install.ps1 -Force
           Copy-Item ./scripts/install/install-templatecli.sh ./artifacts/install-script/install.sh -Force
+          Copy-Item ./.github/workflows/attest-install-scripts.yml ./artifacts/install-script/.github/workflows/attest-install-scripts.yml -Force
 
       - name: Determine signing availability
         id: signing
@@ -111,12 +113,12 @@ jobs:
           set -euo pipefail
 
           VERSION='${{ steps.manifest.outputs.version }}'
-          BRANCH_COMMIT=$(bash ./scripts/publish-branch-content.sh install-scripts ./artifacts/install-script "Publish ${VERSION}")
-
-          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+          if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}" >/dev/null 2>&1; then
             echo "::error::Tag ${VERSION} already exists."
             exit 1
           fi
+
+          BRANCH_COMMIT=$(bash ./scripts/publish-branch-content.sh install-scripts ./artifacts/install-script "Publish ${VERSION}")
 
           git config user.name "${GIT_AUTHOR_NAME:-github-actions[bot]}"
           git config user.email "${GIT_AUTHOR_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"

--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -14,6 +14,7 @@ jobs:
     environment: production
 
     permissions:
+      actions: write
       contents: write
       id-token: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,7 +290,9 @@ jobs:
       - name: Attest final release archives
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
-          subject-path: ./artifacts/release/templatecli-*.zip,./artifacts/release/templatecli-*.tar.gz
+          subject-path: |
+            ./artifacts/release/templatecli-*.zip
+            ./artifacts/release/templatecli-*.tar.gz
 
       - name: Create GitHub release
         env:

--- a/docs/release-and-provenance.md
+++ b/docs/release-and-provenance.md
@@ -33,7 +33,7 @@ This design supports both mutable and immutable consumption. The branch-backed U
 
 The `install-scripts` branch is treated as workflow-managed mutable state. Repositories created from this template typically will not have that branch yet unless the creator explicitly chose to include all branches, so the publication flow is expected to create `install-scripts` on first publish when it is missing. Subsequent publications add regular commits so the branch history is preserved. If repository permissions or branch protection prevent the workflow from creating or updating that branch, the workflow should fail with a clear, actionable error.
 
-`install-scripts.yml` uses the `production` environment for the single approval gate before signing keys are accessed or the public `install-scripts` branch and snapshot tag are updated. `attest-install-scripts.yml` intentionally remains ungated and only publishes attestations and the immutable release for the already-approved snapshot tag.
+`install-scripts.yml` uses the `production` environment for the single approval gate before signing keys are accessed or the public `install-scripts` branch and snapshot tag are updated. The published `install-scripts` snapshot also includes a copy of `.github\workflows\attest-install-scripts.yml` so GitHub can run that workflow on the tag-bound snapshot ref. `attest-install-scripts.yml` intentionally remains ungated and only publishes attestations and the immutable release for the already-approved snapshot tag.
 
 ## Required repository setup
 


### PR DESCRIPTION
## Summary
- Grant `actions: write` to the install-script publication job so it can dispatch the attestation workflow
- Include `attest-install-scripts.yml` in the published install-script snapshot so `workflow_dispatch --ref install-scripts-v*` can run on the tag-bound ref
- Harden attestation workflow concurrency, subject-path formatting, and duplicate tag detection

## Validation
- `git diff --check`
- `bash scripts/verify-shell-syntax.sh`
- staged install-script snapshot smoke test for required files, including `.github/workflows/attest-install-scripts.yml`